### PR TITLE
Partes do nome devem conter 2 ou mais caracteres.

### DIFF
--- a/Projetos/petshop/src/main/java/br/com/tt/petshop/service/ClienteService.java
+++ b/Projetos/petshop/src/main/java/br/com/tt/petshop/service/ClienteService.java
@@ -95,7 +95,7 @@ public class ClienteService {
 //        return true;
 
         return Stream.of(nome.split(SEPARADOR))
-                .allMatch(parte -> parte.length() > 2);
+                .allMatch(parte -> parte.length() >= 2);
     }
 
     /*


### PR DESCRIPTION
Exemplo: "Vinicius Fraga de Castro" não é aceito atualmente, em virtude do "de".